### PR TITLE
Support read-only with GCS buckets that have public objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.lock
+bosh-gcscli
+config.json

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ default: test-int
 
 # build the binary
 build:
-	go build
+	go install
 
 # Fetch base dependencies as well as testing packages
 get-deps:

--- a/Makefile
+++ b/Makefile
@@ -125,3 +125,20 @@ test-fast-int: get-deps clean fmt lint vet build prep-gcs check-int-env
 	 export PUBLIC_BUCKET_NAME="$$(cat public.lock)" && \
 	 export SKIP_LONG_TESTS="yes" && \
 	 ginkgo -r
+
+help:
+	 @echo "common developer commands:"
+	 @echo "  get-deps: fetch developer dependencies"
+	 @echo "  fmt: run gofmt on the codebase"
+	 @echo "  clean: run go clean on the codebase"
+	 @echo "  lint: run go lint on the codebase"
+	 @echo "  vet: run go vet on the codebase"
+	 @echo ""
+	 @echo "common testing commands:"
+	 @echo "  prep-gcs: create external GCS buckets needed for integration testing"
+	 @echo "  clean-gcs: remove external GCS buckets"
+	 @echo "  test-fast-int: run an reduced integration test suite (presubmit)"
+	 @echo "  test-int: run the full integration test (CI only)"
+	 @echo ""
+	 @echo "expected environment variables:"
+	 @echo "  GOOGLE_SERVICE_ACCOUNT=contents of a JSON service account key"

--- a/integration/assertcontext.go
+++ b/integration/assertcontext.go
@@ -115,6 +115,7 @@ func AsReadOnlyCredentials(ctx *AssertContext) {
 		"cannot set read-only AssertContext without config")
 
 	conf.CredentialsSource = config.NoneCredentialsSource
+	conf.ServiceAccountFile = ""
 }
 
 // AsStaticCredentials configures the AssertContext to authenticate explicitly

--- a/integration/configurations.go
+++ b/integration/configurations.go
@@ -108,17 +108,14 @@ func getEncryptedConfigs() ([]TableEntry, error) {
 	}, nil
 }
 
-func getPublicConfigs() ([]TableEntry, error) {
+func getPublicConfig() (*config.GCSCli, error) {
 	public, err := readBucketEnv(publicBucketEnv)
 	if err != nil {
 		return nil, fmt.Errorf(getConfigErrMsg, "public", err)
 	}
 
-	return []TableEntry{
-		Entry("Public bucket",
-			&config.GCSCli{
-				BucketName: public,
-			}),
+	return &config.GCSCli{
+		BucketName: public,
 	}, nil
 }
 

--- a/main.go
+++ b/main.go
@@ -99,28 +99,27 @@ func main() {
 	}
 
 	if *configPath == "" {
-		fmt.Println("no config file provided\nSee -help for usage")
-		os.Exit(1)
+		log.Fatalf("no config file provided\nSee -help for usage\n")
 	}
 
 	configFile, err := os.Open(*configPath)
 	if err != nil {
-		log.Fatalln(err)
+		log.Fatalf("opening config %s: %v\n", *configPath, err)
 	}
 
 	gcsConfig, err := config.NewFromReader(configFile)
 	if err != nil {
-		log.Fatalln(err)
+		log.Fatalf("reading config %s: %v\n", *configPath, err)
 	}
 
 	ctx, gcsClient, err := client.NewSDK(gcsConfig)
 	if err != nil {
-		log.Fatalln(err)
+		log.Fatalf("creating gcs sdk: %v\n", err)
 	}
 
 	blobstoreClient, err := client.New(ctx, gcsClient, &gcsConfig)
 	if err != nil {
-		log.Fatalln(err)
+		log.Fatalf("creating gcs client: %v\n", err)
 	}
 
 	nonFlagArgs := flag.Args()


### PR DESCRIPTION
- Don't validate storage class when in read only mode. This requires credentials (or ACLs) that allow for `storage.buckets.get`. A more likely GCS configuration is a restricted bucket that has some public objects.
- Minor code cleanup (while I'm in the neighborhood)