### PR TITLE
Promote Develop

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+# Contributing
+
+## Submitting an Issue
+We use the [GitHub issue tracker](https://github.com/cloudfoundry/bosh-gcscli/issues) to track bugs and features.
+Before submitting a bug report or feature request, check to make sure it hasn't already been submitted. You can indicate
+support for an existing issue by voting it up. When submitting a bug report, please include a
+[Gist](http://gist.github.com/) that includes a stack trace and any details that may be necessary to reproduce the bug,
+including your gem version, Ruby version, and operating system. Ideally, a bug report should include a pull request with failing specs.
+
+## Submitting a Pull Request
+You can add a feature or bug-fix via pull request.
+1. Fork the project
+1. Create a branch for your feature or fix from the `develop` branch. Replace `your-feature-name` with a description of your feature or fix:
+   ```
+   git checkout -b your-feature-name develop
+   ```
+1. Implement your feature or bug fix
+1. Commit and push your changes
+1. Submit a pull request to the `develop` branch of the [bosh-gcscli] repository. PRs to the master branch are not accepted.
+1. Unit tests and a BOSH release are created for each PR. You should see the status of your PR change to "pending" within a few minutes of submitting it, and then to "passed" or "failed" within 10 minutes.
+
+[bosh-gcscli]: https://github.com/cloudfoundry/bosh-gcscli/

--- a/Makefile
+++ b/Makefile
@@ -91,15 +91,16 @@ prep-gcs: regional-bucket multiregional-bucket public-bucket
 
 # Remove all buckets listed in $StorageClass.lock files.
 clean-gcs:
-	test -s "multiregional.lock" && \
-	test -s "regional.lock" && \
-	test -s "public.lock"
+	@test -s "multiregional.lock" && test -s "regional.lock" && test -s "public.lock"
+	@gsutil rm "gs://$$(cat regional.lock)/*" || true
 	@gsutil rb "gs://$$(cat regional.lock)"
-	rm regional.lock
+	@rm regional.lock
+	@gsutil rm "gs://$$(cat multiregional.lock)/*" || true
 	@gsutil rb "gs://$$(cat multiregional.lock)"
-	rm multiregional.lock
+	@rm multiregional.lock
+	@gsutil rm "gs://$$(cat public.lock)/*" || true
 	@gsutil rb "gs://$$(cat public.lock)"
-	rm public.lock
+	@rm public.lock
 
 # Perform only unit tests
 test-unit: get-deps clean fmt lint vet build

--- a/README.md
+++ b/README.md
@@ -1,87 +1,81 @@
-## GCS CLI
+## bosh-gcscli
 
-A CLI for uploading, fetching and deleting content to/from
-the [GCS blobstore](https://cloud.google.com/storage/). This is **not**
-an official Google Product.
+[![GoDoc](https://godoc.org/github.com/cloudfoundry/bosh-gcscli?status.svg)](https://godoc.org/github.com/cloudfoundry/bosh-gcscli)
+
+
+A Golang CLI for uploading, fetching and deleting content to/from [Google Cloud Storage](https://cloud.google.com/storage/). 
+This tool exists to work with the [bosh-cli](https://github.com/cloudfoundry/bosh-cli) and [director](https://github.com/cloudfoundry/bosh).
+
+This is **not** an official Google Product.
 
 ## Installation
 
-```
+```bash
 go get github.com/cloudfoundry/bosh-gcscli
 ```
 
-## Usage
+## Commands
 
-Given a JSON config file (`config.json`)...
-
-``` json
-{
-  "bucket_name":         "name of GCS bucket (required)",
-
-  "credentials_source":  "flag for credentials
-                          (optional, defaults to Application Default Credentials)
-                          (can be "static" for json_key),
-                          (can be "none" for explicitly no credentials)"
-  "storage_class":       "storage class for objects
-                          (optional, defaults to bucket settings)",
-  "json_key":            "JSON Service Account File
-                          (optional, required for static credentials)",
-  "encryption_key":      "Base64 encoded 32 byte Customer-Supplied
-                          encryption key used to encrypt objects 
-                          (optional)"
-}
-```
-
-
-Empty `credentials_source` implies attempting to use Application Default
-Credentials. `none` as `credentials_source` specifies no read-only scope
-with explicitly no credentials. `static` as `credentials_source` specifies to
-use the [Service Account File](https://developers.google.com/identity/protocols/OAuth2ServiceAccount) included
-in `json_key`.
-
-Empty `storage_class` implies using the default for the bucket.
-
-``` bash
-# Usage
+### Usage
+```bash
 bosh-gcscli --help
-
-# Command: "put"
-# Upload a blob to the GCS blobstore.
+```
+### Upload an object
+```bash
 bosh-gcscli -c config.json put <path/to/file> <remote-blob>
-
-# Command: "get"
-# Fetch a blob from the GCS blobstore.
-# Destination file will be overwritten if exists.
+```
+### Fetch an object
+```bash
 bosh-gcscli -c config.json get <remote-blob> <path/to/file>
-
-# Command: "delete"
-# Remove a blob from the GCS blobstore.
+```
+### Delete an object
+```bash
 bosh-gcscli -c config.json delete <remote-blob>
-
-# Command: "exists"
-# Checks if blob exists in the GCS blobstore.
-bosh-gcscli -c config.json exists <remote-blob>
+```
+### Check if an object exists
+```bash
+bosh-gcscli -c config.json exists <remote-blob>```
 ```
 
-Alternatively, this package's underlying client can be used to access GCS,
-see the [godoc](https://godoc.org/github.com/cloudfoundry/bosh-gcscli)
-for more information.
+## Configuration
+The command line tool expects a JSON configuration file. Run `bosh-gcscli --help` for details.
 
-## Tooling
+### Authentication Methods (`credentials_source`)
+* `static`: A [service account](https://cloud.google.com/iam/docs/creating-managing-service-account-keys) key will be provided via the `json_key` field.
+* `none`: No credentials are provided. The client is reading from a public bucket.
+* &lt;empty&gt;: [Application Default Credentials](https://developers.google.com/identity/protocols/application-default-credentials)
+  will be used if they exist (either through `gcloud auth application-default login` or a [service account](https://cloud.google.com/iam/docs/understanding-service-accounts)).
+  If they don't exist the client will fall back to `none` behavior.
 
-A Makefile is provided for ease of development. Targets are annotated
-with descriptions.
+## Running Integration Tests
 
-gvt is used for vendoring. For full usage, see the [manual at godoc](https://godoc.org/github.com/FiloSottile/gvt).
+1. Ensure [gcloud](https://cloud.google.com/sdk/downloads) is installed and you have authenticated (`gcloud auth login`).
+   These credentials will be used by the Makefile to create/destroy Google Cloud Storage buckets for testing.
+1. Set the Google Cloud project: `gcloud config set project <your project>`
+1. Generate a service account with the `Storage Admin` role for your project and set the contents as 
+    the environment variable `GOOGLE_APPLICATION_CREDENTIALS`, for example:
+   ```bash
+   export project_id=$(gcloud config get-value project)
 
-Integration tests expect to be run from a host with [Application Default
-Credentials](https://developers.google.com/identity/protocols/application-default-credentials)
-available which has permissions to create and delete buckets.
-Application Default Credentials are present on any GCE instance and inherit
-the permisions of the [service account](https://cloud.google.com/iam/docs/service-accounts)
-assigned to the instance.
+   export service_account_name=bosh-gcscli-integration-tests
+   export service_account_email=${service_account_name}@${project_id}.iam.gserviceaccount.com
+   credentials_file=$(mktemp)
+
+   gcloud config set project ${project_id}
+   gcloud iam service-accounts create ${service_account_name} --display-name "Integration Test Access for bosh-gcscli"
+   gcloud iam service-accounts keys create ${credentials_file} --iam-account ${service_account_email}
+   gcloud project add-iam-policy-binding ${project_id} --member serviceAccount:${service_account_email} --role roles/storage.admin
+  
+   export GOOGLE_APPLICATION_CREDENTIALS="$(cat ${credentials_file})"
+   ```
+1. Run the unit and fast integration tests: `make test-fast-int`
+1. Clean up buckets: `make clean-gcs`
+
+## Development
+
+* A Makefile is provided that automates integration testing. Try `make help` to get started.
+* [gvt](https://godoc.org/github.com/FiloSottile/gvt) is used for vendoring.
 
 ## License
 
-This library is licensed under Apache 2.0. Full license text is
-available in [LICENSE](LICENSE).
+This tool is licensed under Apache 2.0. Full license text is available in [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ The command line tool expects a JSON configuration file. Run `bosh-gcscli --help
 * A Makefile is provided that automates integration testing. Try `make help` to get started.
 * [gvt](https://godoc.org/github.com/FiloSottile/gvt) is used for vendoring.
 
+## Contributing
+
+For details on how to contribute to this project - including filing bug reports and contributing code changes - please see [CONTRIBUTING.md](./CONTRIBUTING.md).
+
 ## License
 
 This tool is licensed under Apache 2.0. Full license text is available in [LICENSE](LICENSE).

--- a/ci/.gitignore
+++ b/ci/.gitignore
@@ -1,0 +1,1 @@
+credentials.yml

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -65,10 +65,6 @@ jobs:
           params: {file: out-linux/bosh-gcscli-*-linux-amd64}
         - put: release-bucket-windows
           params: {file: out-windows/bosh-gcscli-*-windows-amd64.exe}
-      - put: gcscli-src
-        resource: bosh-gcscli-out
-        params: {repository: gcscli-src, tag: version-semver/number, tag_prefix: v}
-
 
 resources:
   - name: bosh-gcscli-src-in
@@ -82,6 +78,7 @@ resources:
     source:
       initial_version: 0.0.1
       key: current-version
+      endpoint: storage.googleapis.com
       bucket: {{gcscli_release_bucket}}
       access_key_id: {{gcscli_release_bucket_access_key}}
       secret_access_key: {{gcscli_release_bucket_secret_key}}
@@ -101,10 +98,3 @@ resources:
       bucket: {{gcscli_release_bucket}}
       access_key_id: {{gcscli_release_bucket_access_key}}
       secret_access_key: {{gcscli_release_bucket_secret_key}}
-
-  - name: bosh-gcscli-out
-    type: git
-    source:
-      uri: git@github.com:cloudfoundry/bosh-gcscli.git
-      branch: master
-      private_key: {{github_deployment_key_gcscli}}

--- a/ci/tasks/build.sh
+++ b/ci/tasks/build.sh
@@ -1,14 +1,12 @@
 #!/usr/bin/env bash
 
-set -e
+set -ue
 
 my_dir="$( cd $(dirname $0) && pwd )"
-release_dir="$( cd ${my_dir} && cd ../.. && pwd )"
-workspace_dir="$( cd ${release_dir} && cd ../../../.. && pwd )"
-
-source ${release_dir}/ci/tasks/utils.sh
-export GOPATH=${workspace_dir}
-export PATH=${GOPATH}/bin:${PATH}
+pushd ${my_dir} > /dev/null
+    source utils.sh
+    set_env
+popd > /dev/null
 
 # inputs
 semver_dir="${workspace_dir}/version-semver"

--- a/ci/tasks/run-fast-int.sh
+++ b/ci/tasks/run-fast-int.sh
@@ -1,32 +1,14 @@
 #!/usr/bin/env bash
 
-set -e
+set -ue
 
 my_dir="$( cd $(dirname $0) && pwd )"
-release_dir="$( cd ${my_dir} && cd ../.. && pwd )"
-workspace_dir="$( cd ${release_dir} && cd ../../../.. && pwd )"
-
-pushd ${release_dir} > /dev/null
-
-source ci/tasks/utils.sh
-
+pushd ${my_dir} > /dev/null
+    source utils.sh
+    set_env
 popd > /dev/null
 
-check_param google_project
-check_param google_json_key_data
-
-gcloud config set project $google_project
-
-echo $google_json_key_data > key.json
-gcloud auth activate-service-account --key-file=key.json
-
-export GOPATH=${workspace_dir}
-export PATH=${GOPATH}/bin:${PATH}
-
-pushd ${release_dir} > /dev/null
-
-GOOGLE_SERVICE_ACCOUNT=$google_json_key_data make test-fast-int
-
-make clean-gcs
-
-popd > /dev/null
+pushd ${release_dir}
+    trap clean_gcs EXIT
+    GOOGLE_SERVICE_ACCOUNT=$google_json_key_data make test-fast-int
+popd

--- a/ci/tasks/run-fast-int.sh
+++ b/ci/tasks/run-fast-int.sh
@@ -6,6 +6,7 @@ my_dir="$( cd $(dirname $0) && pwd )"
 pushd ${my_dir} > /dev/null
     source utils.sh
     set_env
+    gcloud_login
 popd > /dev/null
 
 pushd ${release_dir}

--- a/ci/tasks/run-int.sh
+++ b/ci/tasks/run-int.sh
@@ -6,6 +6,7 @@ my_dir="$( cd $(dirname $0) && pwd )"
 pushd ${my_dir} > /dev/null
     source utils.sh
     set_env
+    gcloud_login
 popd > /dev/null
 
 pushd ${release_dir}

--- a/ci/tasks/run-int.sh
+++ b/ci/tasks/run-int.sh
@@ -1,32 +1,14 @@
 #!/usr/bin/env bash
 
-set -e
+set -ue
 
 my_dir="$( cd $(dirname $0) && pwd )"
-release_dir="$( cd ${my_dir} && cd ../.. && pwd )"
-workspace_dir="$( cd ${release_dir} && cd ../../../.. && pwd )"
-
-pushd ${release_dir} > /dev/null
-
-source ci/tasks/utils.sh
-
+pushd ${my_dir} > /dev/null
+    source utils.sh
+    set_env
 popd > /dev/null
 
-check_param google_project
-check_param google_json_key_data
-
-gcloud config set project $google_project
-
-echo $google_json_key_data > key.json
-gcloud auth activate-service-account --key-file=key.json
-
-export GOPATH=${workspace_dir}
-export PATH=${GOPATH}/bin:${PATH}
-
-pushd ${release_dir} > /dev/null
-
-GOOGLE_SERVICE_ACCOUNT=$google_json_key_data make test-int
-
-make clean-gcs
-
-popd > /dev/null
+pushd ${release_dir}
+    trap clean_gcs EXIT
+    GOOGLE_SERVICE_ACCOUNT=$google_json_key_data make test-int
+popd

--- a/ci/tasks/run-unit.sh
+++ b/ci/tasks/run-unit.sh
@@ -1,17 +1,13 @@
 #!/usr/bin/env bash
 
-set -e
-
+set -ue
 
 my_dir="$( cd $(dirname $0) && pwd )"
-release_dir="$( cd ${my_dir} && cd ../.. && pwd )"
-workspace_dir="$( cd ${release_dir} && cd ../../../.. && pwd )"
+pushd ${my_dir} > /dev/null
+    source utils.sh
+    set_env
+popd > /dev/null
 
-export GOPATH=${workspace_dir}
-export PATH=${GOPATH}/bin:${PATH}
-
-pushd ${release_dir} > /dev/null
-
-make test-unit
-
+pushd ${release_dir}
+    make test-unit
 popd > /dev/null

--- a/ci/tasks/utils.sh
+++ b/ci/tasks/utils.sh
@@ -41,3 +41,16 @@ function add_on_exit {
     trap on_exit EXIT
   fi
 }
+
+function clean_gcs {
+    make clean-gcs
+}
+
+function set_env {
+    export my_dir="$( cd $(dirname $0) && pwd )"
+    export release_dir="$( cd ${my_dir} && cd ../.. && pwd )"
+    export workspace_dir="$( cd ${release_dir} && cd ../../../.. && pwd )"
+
+    export GOPATH=${workspace_dir}
+    export PATH=${GOPATH}/bin:${PATH}
+}

--- a/ci/tasks/utils.sh
+++ b/ci/tasks/utils.sh
@@ -43,7 +43,9 @@ function add_on_exit {
 }
 
 function clean_gcs {
-    make clean-gcs
+    pushd ${release_dir}
+        make clean-gcs
+    popd
 }
 
 function set_env {

--- a/ci/tasks/utils.sh
+++ b/ci/tasks/utils.sh
@@ -47,10 +47,20 @@ function clean_gcs {
 }
 
 function set_env {
-    export my_dir="$( cd $(dirname $0) && pwd )"
+    my_dir=$(dirname "$(readlink -f "$0")")
     export release_dir="$( cd ${my_dir} && cd ../.. && pwd )"
     export workspace_dir="$( cd ${release_dir} && cd ../../../.. && pwd )"
 
     export GOPATH=${workspace_dir}
     export PATH=${GOPATH}/bin:${PATH}
+}
+
+function gcloud_login {
+    check_param 'google_project'
+    check_param 'google_json_key_data'
+
+    keyfile=$(mktemp)
+    gcloud config set project ${google_project}
+    echo ${google_json_key_data} > ${keyfile}
+    gcloud auth activate-service-account --key-file=${keyfile}
 }

--- a/client/client.go
+++ b/client/client.go
@@ -75,15 +75,13 @@ func (client GCSBlobstore) getObjectHandle(src string) *storage.ObjectHandle {
 func New(ctx context.Context, gcsClient *storage.Client,
 	gcscliConfig *config.GCSCli) (GCSBlobstore, error) {
 	if gcsClient == nil {
-		return GCSBlobstore{},
-			errors.New("nil client causes invalid blobstore")
+		return GCSBlobstore{}, errors.New("nil client causes invalid blobstore")
 	}
 	if gcscliConfig == nil {
-		return GCSBlobstore{},
-			errors.New("nil config causes invalid blobstore")
+		return GCSBlobstore{}, errors.New("nil config causes invalid blobstore")
 	}
-	blobstore := GCSBlobstore{gcsClient, gcscliConfig}
-	return blobstore, blobstore.validateRemoteConfig()
+
+	return GCSBlobstore{gcsClient, gcscliConfig}, nil
 }
 
 // Get fetches a blob from the GCS blobstore.
@@ -106,6 +104,10 @@ func (client GCSBlobstore) Get(src string, dest io.Writer) error {
 func (client GCSBlobstore) Put(src io.ReadSeeker, dest string) error {
 	if client.config.IsReadOnly() {
 		return ErrInvalidROWriteOperation
+	}
+
+	if err := client.validateRemoteConfig(); err != nil {
+		return err
 	}
 
 	remoteWriter := client.getObjectHandle(dest).NewWriter(context.Background())

--- a/client/sdk.go
+++ b/client/sdk.go
@@ -34,11 +34,8 @@ import (
 
 const uaString = "bosh-gcscli"
 
-// NewSDK returns context and client necessary to instantiate a client
-// based off of the provided configuration.
-func NewSDK(c config.GCSCli) (context.Context, *storage.Client, error) {
-	ctx := context.Background()
-
+// NewSDK builds the GCS SDK client from a valid config.GCSCli
+func NewSDK(ctx context.Context, c config.GCSCli) (*storage.Client, error) {
 	var client *storage.Client
 	var err error
 	ua := option.WithUserAgent(uaString)
@@ -46,8 +43,7 @@ func NewSDK(c config.GCSCli) (context.Context, *storage.Client, error) {
 	switch c.CredentialsSource {
 	case config.ApplicationDefaultCredentialsSource:
 		var tokenSource oauth2.TokenSource
-		tokenSource, err = google.DefaultTokenSource(ctx,
-			storage.ScopeFullControl)
+		tokenSource, err = google.DefaultTokenSource(ctx, storage.ScopeFullControl)
 		if err == nil {
 			opt = option.WithTokenSource(tokenSource)
 		}
@@ -55,8 +51,7 @@ func NewSDK(c config.GCSCli) (context.Context, *storage.Client, error) {
 		opt = option.WithHTTPClient(http.DefaultClient)
 	case config.ServiceAccountFileCredentialsSource:
 		var token *jwt.Config
-		token, err = google.JWTConfigFromJSON([]byte(c.ServiceAccountFile),
-			storage.ScopeFullControl)
+		token, err = google.JWTConfigFromJSON([]byte(c.ServiceAccountFile), storage.ScopeFullControl)
 		if err == nil {
 			tokenSource := token.TokenSource(ctx)
 			opt = option.WithTokenSource(tokenSource)
@@ -65,9 +60,8 @@ func NewSDK(c config.GCSCli) (context.Context, *storage.Client, error) {
 		err = errors.New("unknown credentials_source in configuration")
 	}
 	if err != nil {
-		return ctx, client, err
+		return client, err
 	}
 
-	client, err = storage.NewClient(ctx, ua, opt)
-	return ctx, client, err
+	return storage.NewClient(ctx, ua, opt)
 }

--- a/client/sdk.go
+++ b/client/sdk.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 
-	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 
 	"google.golang.org/api/option"
@@ -29,39 +28,34 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/cloudfoundry/bosh-gcscli/config"
-	"golang.org/x/oauth2/jwt"
 )
 
 const uaString = "bosh-gcscli"
 
-// NewSDK builds the GCS SDK client from a valid config.GCSCli
-func NewSDK(ctx context.Context, c config.GCSCli) (*storage.Client, error) {
-	var client *storage.Client
-	var err error
-	ua := option.WithUserAgent(uaString)
-	var opt option.ClientOption
-	switch c.CredentialsSource {
-	case config.ApplicationDefaultCredentialsSource:
-		var tokenSource oauth2.TokenSource
-		tokenSource, err = google.DefaultTokenSource(ctx, storage.ScopeFullControl)
-		if err == nil {
-			opt = option.WithTokenSource(tokenSource)
-		}
+func newStorageClient(ctx context.Context, cfg *config.GCSCli) (*storage.Client, bool, error) {
+	// default to a read-only client
+	readOnly := true
+	opt := option.WithHTTPClient(http.DefaultClient)
+
+	switch cfg.CredentialsSource {
 	case config.NoneCredentialsSource:
-		opt = option.WithHTTPClient(http.DefaultClient)
-	case config.ServiceAccountFileCredentialsSource:
-		var token *jwt.Config
-		token, err = google.JWTConfigFromJSON([]byte(c.ServiceAccountFile), storage.ScopeFullControl)
-		if err == nil {
-			tokenSource := token.TokenSource(ctx)
+		// no-op
+	case config.DefaultCredentialsSource:
+		// attempt to load the application default credentials
+		if tokenSource, err := google.DefaultTokenSource(ctx, storage.ScopeFullControl); err == nil {
 			opt = option.WithTokenSource(tokenSource)
+			readOnly = false
+		}
+	case config.ServiceAccountFileCredentialsSource:
+		if token, err := google.JWTConfigFromJSON([]byte(cfg.ServiceAccountFile), storage.ScopeFullControl); err == nil {
+			opt = option.WithTokenSource(token.TokenSource(ctx))
+			readOnly = false
 		}
 	default:
-		err = errors.New("unknown credentials_source in configuration")
-	}
-	if err != nil {
-		return client, err
+		return nil, false, errors.New("unknown credentials_source in configuration")
 	}
 
-	return storage.NewClient(ctx, ua, opt)
+	gcs, err := storage.NewClient(ctx, option.WithUserAgent(uaString), opt)
+
+	return gcs, readOnly, err
 }

--- a/config/config.go
+++ b/config/config.go
@@ -27,7 +27,7 @@ type GCSCli struct {
 	// BucketName is the GCS bucket operations will use.
 	BucketName string `json:"bucket_name"`
 	// CredentialsSource is the location of a Service Account File.
-	// If left empty, Application Default Credentials will be used.
+	// If left empty, Application Default Credentials will be used if available.
 	// If equal to 'none', read-only scope will be used.
 	// If equal to 'static', json_key will be used.
 	CredentialsSource string `json:"credentials_source"`
@@ -52,9 +52,10 @@ const (
 	defaultMultiRegionalStorageClass = "MULTI_REGIONAL"
 )
 
-// ApplicationDefaultCredentialsSource specifies that
-// Application Default Credentials should be used for authentication.
-const ApplicationDefaultCredentialsSource = ""
+// DefaultCredentialsSource specifies that credentials should be detected.
+// Application Default Credentials will be used if avaliable.
+// A read-only client will be used otherwise.
+const DefaultCredentialsSource = ""
 
 // NoneCredentialsSource specifies that credentials are explicitly empty
 // and that the client should be restricted to a read-only scope.
@@ -142,9 +143,4 @@ func (c *GCSCli) FitCompatibleLocation(loc string) error {
 	}
 
 	return validLocationStorageClass(loc, c.StorageClass)
-}
-
-// IsReadOnly returns if the configuration is limited to only read operations.
-func (c *GCSCli) IsReadOnly() bool {
-	return c.CredentialsSource == NoneCredentialsSource
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -160,17 +160,6 @@ var _ = Describe("BlobstoreClient configuration", func() {
 		})
 	})
 
-	Describe("when credentials_source is 'none'", func() {
-		dummyJSONBytes := []byte(`{"credentials_source": "none", "bucket_name": "some-bucket"}`)
-		dummyJSONReader := bytes.NewReader(dummyJSONBytes)
-
-		It("is ReadOnly", func() {
-			c, err := NewFromReader(dummyJSONReader)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(c.IsReadOnly()).To(BeTrue())
-		})
-	})
-
 	Describe("when credentials_source is not specified", func() {
 		dummyJSONBytes := []byte(`{"credentials_source": "", "bucket_name": "some-bucket"}`)
 		dummyJSONReader := bytes.NewReader(dummyJSONBytes)

--- a/integration/assertcontext.go
+++ b/integration/assertcontext.go
@@ -25,6 +25,7 @@ import (
 	"io/ioutil"
 
 	. "github.com/onsi/gomega"
+	"golang.org/x/net/context"
 )
 
 // GoogleAppCredentialsEnv is the environment variable
@@ -69,6 +70,9 @@ type AssertContext struct {
 	// options are the AssertContextConfigOption which are used to modify
 	// the configuration whenever AddConfig is called.
 	options []AssertContextConfigOption
+
+	// ctx is the context used by the individual test
+	ctx context.Context
 }
 
 // NewAssertContext returns an AssertContext with all fields
@@ -86,6 +90,7 @@ func NewAssertContext(options ...AssertContextConfigOption) AssertContext {
 		GCSFileName:        GenerateRandomString(),
 		serviceAccountFile: serviceAccountFile,
 		options:            options,
+		ctx:                context.Background(),
 	}
 }
 

--- a/integration/assertcontext.go
+++ b/integration/assertcontext.go
@@ -151,7 +151,7 @@ func AsDefaultCredentials(ctx *AssertContext) {
 	ctx.serviceAccountPath = tempFile.Name()
 	os.Setenv(GoogleAppCredentialsEnv, ctx.serviceAccountPath)
 
-	conf.CredentialsSource = config.ApplicationDefaultCredentialsSource
+	conf.CredentialsSource = config.DefaultCredentialsSource
 }
 
 // Clone returns a new AssertContext configured using the provided options.

--- a/integration/assertions.go
+++ b/integration/assertions.go
@@ -17,17 +17,10 @@
 package integration
 
 import (
-	"context"
-	"fmt"
-	"io"
 	"os"
 
-	"github.com/cloudfoundry/bosh-gcscli/client"
-
-	"crypto/rand"
 	"io/ioutil"
 
-	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
@@ -81,104 +74,4 @@ func AssertLifecycleWorks(gcsCLIPath string, ctx AssertContext) {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(session.ExitCode()).To(Equal(3))
 	Expect(session.Err.Contents()).To(MatchRegexp("File '.*' does not exist in bucket '.*'"))
-}
-
-// AssertDeleteNonexistentWorks tests that attempting to delete a non-existent
-// file will be silently ignored.
-func AssertDeleteNonexistentWorks(gcsCLIPath string, ctx AssertContext) {
-	session, err := RunGCSCLI(gcsCLIPath, ctx.ConfigPath,
-		"delete", ctx.GCSFileName)
-	Expect(err).ToNot(HaveOccurred())
-	Expect(session.ExitCode()).To(BeZero())
-}
-
-// randReadSeeker is a ReadSeeker which returns random content and
-// non-nil error for every operation.
-//
-// crypto/rand is used to ensure any compression
-// applied to the reader's output doesn't effect the work we intend to do.
-type randReadSeeker struct {
-	reader io.Reader
-}
-
-func newrandReadSeeker(maxSize int64) randReadSeeker {
-	limited := io.LimitReader(rand.Reader, maxSize)
-	return randReadSeeker{limited}
-}
-
-func (rrs *randReadSeeker) Read(p []byte) (n int, err error) {
-	return rrs.reader.Read(p)
-}
-
-func (rrs *randReadSeeker) Seek(offset int64, whenc int) (n int64, err error) {
-	return offset, nil
-}
-
-const twoGB = 1024 * 1024 * 1024 * 2
-
-// AssertMultipartPutWorks tests that attempting to upload a large,
-// multipart blob succeeds.
-func AssertMultipartPutWorks(gcsCLIPath string, ctx AssertContext) {
-	if os.Getenv(NoLongEnv) != "" {
-		Skip(fmt.Sprintf(NoLongMsg, NoLongEnv))
-	}
-
-	limited := newrandReadSeeker(twoGB)
-
-	_, gcsClient, err := client.NewSDK(*ctx.Config)
-	Expect(err).ToNot(HaveOccurred())
-	blobstoreClient, err := client.New(context.Background(),
-		gcsClient, ctx.Config)
-	Expect(err).ToNot(HaveOccurred())
-
-	err = blobstoreClient.Put(&limited, ctx.GCSFileName)
-	Expect(err).ToNot(HaveOccurred())
-
-	blobstoreClient.Delete(ctx.GCSFileName)
-	Expect(err).ToNot(HaveOccurred())
-}
-
-// badReadSeeker is a ReadSeeker which returns a non-nil error
-// for every operation.
-type badReadSeeker struct{}
-
-var badReadSeekerErr = io.ErrUnexpectedEOF
-
-func (brs *badReadSeeker) Read(p []byte) (n int, err error) {
-	return 0, badReadSeekerErr
-}
-
-func (brs *badReadSeeker) Seek(offset int64, whenc int) (n int64, err error) {
-	return 0, badReadSeekerErr
-}
-
-// AssertBrokenSourcePutFails tests that a broken upload will cause a failure
-func AssertBrokenSourcePutFails(gcsCLIPath string, ctx AssertContext) {
-	_, gcsClient, err := client.NewSDK(*ctx.Config)
-	Expect(err).ToNot(HaveOccurred())
-	blobstoreClient, err := client.New(context.Background(),
-		gcsClient, ctx.Config)
-	Expect(err).ToNot(HaveOccurred())
-
-	err = blobstoreClient.Put(&badReadSeeker{}, ctx.GCSFileName)
-	Expect(err).To(HaveOccurred())
-}
-
-// AssertGetNonexistentFails tests that attempting to get a non-existent
-// object will fail.
-func AssertGetNonexistentFails(gcsCLIPath string, ctx AssertContext) {
-	session, err := RunGCSCLI(gcsCLIPath, ctx.ConfigPath,
-		"get", ctx.GCSFileName, "/dev/null")
-	Expect(err).ToNot(HaveOccurred())
-	Expect(session.ExitCode()).ToNot(BeZero())
-	Expect(session.Err.Contents()).To(ContainSubstring("object doesn't exist"))
-}
-
-// AssertPutFails tests that whatever context is passed will cause a put
-// operation to fail.
-func AssertPutFails(gcsCLIPath string, ctx AssertContext) {
-	session, err := RunGCSCLI(gcsCLIPath, ctx.ConfigPath,
-		"put", ctx.ContentFile, ctx.GCSFileName)
-	Expect(err).ToNot(HaveOccurred())
-	Expect(session.ExitCode()).ToNot(BeZero())
 }

--- a/integration/configurations.go
+++ b/integration/configurations.go
@@ -59,15 +59,6 @@ func getBaseConfigs() ([]TableEntry, error) {
 			&config.GCSCli{
 				BucketName: multiRegional,
 			}),
-		Entry("Regional bucket, default StorageClass",
-			&config.GCSCli{
-				BucketName: regional,
-			}),
-		Entry("MultiRegional bucket, explicit StorageClass",
-			&config.GCSCli{
-				BucketName:   multiRegional,
-				StorageClass: "MULTI_REGIONAL",
-			}),
 		Entry("Regional bucket, explicit StorageClass",
 			&config.GCSCli{
 				BucketName:   regional,

--- a/integration/configurations.go
+++ b/integration/configurations.go
@@ -76,11 +76,8 @@ var encryptionKeyBytes = []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14
 var encryptionKeyBytesHash = sha256.Sum256(encryptionKeyBytes)
 
 func getEncryptedConfigs() ([]TableEntry, error) {
-	var regional, multiRegional string
+	var multiRegional string
 	var err error
-	if regional, err = readBucketEnv(regionalBucketEnv); err != nil {
-		return nil, fmt.Errorf(getConfigErrMsg, "encrypted", err)
-	}
 	if multiRegional, err = readBucketEnv(multiRegionalBucketEnv); err != nil {
 		return nil, fmt.Errorf(getConfigErrMsg, "encrypted", err)
 	}
@@ -89,11 +86,6 @@ func getEncryptedConfigs() ([]TableEntry, error) {
 		Entry("MultiRegional bucket, default StorageClass, encrypted",
 			&config.GCSCli{
 				BucketName:    multiRegional,
-				EncryptionKey: encryptionKeyBytes,
-			}),
-		Entry("Regional bucket, default StorageClass, encrypted",
-			&config.GCSCli{
-				BucketName:    regional,
 				EncryptionKey: encryptionKeyBytes,
 			}),
 	}, nil
@@ -110,7 +102,7 @@ func getPublicConfig() (*config.GCSCli, error) {
 	}, nil
 }
 
-func getStorageCompatConfigs() ([]TableEntry, error) {
+func getInvalidStorageClassConfigs() ([]TableEntry, error) {
 	var regional, multiRegional string
 	var err error
 	if regional, err = readBucketEnv(regionalBucketEnv); err != nil {
@@ -121,11 +113,11 @@ func getStorageCompatConfigs() ([]TableEntry, error) {
 	}
 
 	return []TableEntry{
-		Entry("MultiRegional bucket, regional StorageClass", &config.GCSCli{
+		Entry("Multi-Region bucket, regional StorageClass", &config.GCSCli{
 			BucketName:   multiRegional,
 			StorageClass: "REGIONAL",
 		}),
-		Entry("Regional bucket, multiregional StorageClass", &config.GCSCli{
+		Entry("Regional bucket, Multi-Region StorageClass", &config.GCSCli{
 			BucketName:   regional,
 			StorageClass: "MULTI_REGIONAL",
 		}),

--- a/integration/configurations.go
+++ b/integration/configurations.go
@@ -17,7 +17,6 @@
 package integration
 
 import (
-	"crypto/sha256"
 	"fmt"
 	"os"
 
@@ -73,23 +72,6 @@ func getBaseConfigs() []TableEntry {
 	return []TableEntry{
 		Entry("Regional bucket, default StorageClass", regional),
 		Entry("MultiRegion bucket, default StorageClass", multiRegion),
-	}
-}
-
-// encryptionKeyBytes are used as the key in tests requiring encryption.
-var encryptionKeyBytes = []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31}
-
-// encryptionKeyBytesHash is the has of the encryptionKeyBytes
-//
-// Typical usage is ensuring the encryption key is actually used by GCS.
-var encryptionKeyBytesHash = sha256.Sum256(encryptionKeyBytes)
-
-func getEncryptedConfigs() []TableEntry {
-	cfg := getMultiRegionConfig()
-	cfg.EncryptionKey = encryptionKeyBytes
-
-	return []TableEntry{
-		Entry("MultiRegional bucket, default StorageClass, encrypted", cfg),
 	}
 }
 

--- a/integration/gcs_encryption_test.go
+++ b/integration/gcs_encryption_test.go
@@ -17,10 +17,23 @@
 package integration
 
 import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+
+	"github.com/cloudfoundry/bosh-gcscli/client"
 	"github.com/cloudfoundry/bosh-gcscli/config"
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
 )
+
+// encryptionKeyBytes are used as the key in tests requiring encryption.
+var encryptionKeyBytes = []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31}
+
+// encryptionKeyBytesHash is the has of the encryptionKeyBytes
+//
+// Typical usage is ensuring the encryption key is actually used by GCS.
+var encryptionKeyBytesHash = sha256.Sum256(encryptionKeyBytes)
 
 var _ = Describe("Integration", func() {
 	Context("general (Default Applicaton Credentials) configuration", func() {
@@ -29,36 +42,77 @@ var _ = Describe("Integration", func() {
 			cfg *config.GCSCli
 		)
 		BeforeEach(func() {
-			ctx = NewAssertContext(AsDefaultCredentials)
 			cfg = getMultiRegionConfig()
 			cfg.EncryptionKey = encryptionKeyBytes
 
+			ctx = NewAssertContext(AsDefaultCredentials)
+			ctx.AddConfig(cfg)
 		})
 		AfterEach(func() {
 			ctx.Cleanup()
 		})
 
-		encryptedConfigs := getEncryptedConfigs()
+		// tests that a blob uploaded with a specified encryption_key can be downloaded again.
+		It("can perform encrypted lifecycle", func() {
+			AssertLifecycleWorks(gcsCLIPath, ctx)
+		})
 
-		DescribeTable("Get with correct encryption_key works",
-			func(config *config.GCSCli) {
-				ctx.AddConfig(config)
-				AssertEncryptionWorks(gcsCLIPath, ctx)
-			},
-			encryptedConfigs...)
+		// tests that uploading a blob with encryption
+		// results in failure to download when the key is changed.
+		It("fails to get with the wrong encryption_key", func() {
+			Expect(ctx.Config.EncryptionKey).ToNot(BeNil(),
+				"Need encryption key for test")
 
-		DescribeTable("Get with wrong encryption_key should fail",
-			func(config *config.GCSCli) {
-				ctx.AddConfig(config)
-				AssertWrongKeyEncryptionFails(gcsCLIPath, ctx)
-			},
-			encryptedConfigs...)
+			session, err := RunGCSCLI(gcsCLIPath, ctx.ConfigPath,
+				"put", ctx.ContentFile, ctx.GCSFileName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(session.ExitCode()).To(BeZero())
 
-		DescribeTable("Get with no encryption_key should fail",
-			func(config *config.GCSCli) {
-				ctx.AddConfig(config)
-				AssertNoKeyEncryptionFails(gcsCLIPath, ctx)
-			},
-			encryptedConfigs...)
+			_, gcsClient, err := client.NewSDK(*ctx.Config)
+			Expect(err).ToNot(HaveOccurred())
+			blobstoreClient, err := client.New(context.Background(),
+				gcsClient, ctx.Config)
+			Expect(err).ToNot(HaveOccurred())
+
+			ctx.Config.EncryptionKey[0]++
+
+			var target bytes.Buffer
+			err = blobstoreClient.Get(ctx.GCSFileName, &target)
+			Expect(err).To(HaveOccurred())
+
+			session, err = RunGCSCLI(gcsCLIPath, ctx.ConfigPath,
+				"delete", ctx.GCSFileName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(session.ExitCode()).To(BeZero())
+		})
+
+		// tests that uploading a blob with encryption
+		// results in failure to download without encryption.
+		It("fails to get with no encryption_key", func() {
+			Expect(ctx.Config.EncryptionKey).ToNot(BeNil(),
+				"Need encryption key for test")
+
+			session, err := RunGCSCLI(gcsCLIPath, ctx.ConfigPath,
+				"put", ctx.ContentFile, ctx.GCSFileName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(session.ExitCode()).To(BeZero())
+
+			_, gcsClient, err := client.NewSDK(*ctx.Config)
+			Expect(err).ToNot(HaveOccurred())
+			blobstoreClient, err := client.New(context.Background(),
+				gcsClient, ctx.Config)
+			Expect(err).ToNot(HaveOccurred())
+
+			ctx.Config.EncryptionKey = nil
+
+			var target bytes.Buffer
+			err = blobstoreClient.Get(ctx.GCSFileName, &target)
+			Expect(err).To(HaveOccurred())
+
+			session, err = RunGCSCLI(gcsCLIPath, ctx.ConfigPath,
+				"delete", ctx.GCSFileName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(session.ExitCode()).To(BeZero())
+		})
 	})
 })

--- a/integration/gcs_encryption_test.go
+++ b/integration/gcs_encryption_test.go
@@ -67,9 +67,7 @@ var _ = Describe("Integration", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(session.ExitCode()).To(BeZero())
 
-			gcsClient, err := client.NewSDK(env.ctx, *env.Config)
-			Expect(err).ToNot(HaveOccurred())
-			blobstoreClient, err := client.New(env.ctx, gcsClient, env.Config)
+			blobstoreClient, err := client.New(env.ctx, env.Config)
 			Expect(err).ToNot(HaveOccurred())
 
 			env.Config.EncryptionKey[0]++
@@ -93,9 +91,7 @@ var _ = Describe("Integration", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(session.ExitCode()).To(BeZero())
 
-			gcsClient, err := client.NewSDK(env.ctx, *env.Config)
-			Expect(err).ToNot(HaveOccurred())
-			blobstoreClient, err := client.New(env.ctx, gcsClient, env.Config)
+			blobstoreClient, err := client.New(env.ctx, env.Config)
 			Expect(err).ToNot(HaveOccurred())
 
 			env.Config.EncryptionKey = nil

--- a/integration/gcs_encryption_test.go
+++ b/integration/gcs_encryption_test.go
@@ -20,23 +20,25 @@ import (
 	"github.com/cloudfoundry/bosh-gcscli/config"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Integration", func() {
 	Context("general (Default Applicaton Credentials) configuration", func() {
-		var ctx AssertContext
+		var (
+			ctx AssertContext
+			cfg *config.GCSCli
+		)
 		BeforeEach(func() {
 			ctx = NewAssertContext(AsDefaultCredentials)
+			cfg = getMultiRegionConfig()
+			cfg.EncryptionKey = encryptionKeyBytes
+
 		})
 		AfterEach(func() {
 			ctx.Cleanup()
 		})
 
-		encryptedConfigs, configErr := getEncryptedConfigs()
-		It("fetches configurations", func() {
-			Expect(configErr).To(BeNil(), "failed to get configurations")
-		})
+		encryptedConfigs := getEncryptedConfigs()
 
 		DescribeTable("Get with correct encryption_key works",
 			func(config *config.GCSCli) {

--- a/integration/gcs_general_test.go
+++ b/integration/gcs_general_test.go
@@ -17,10 +17,54 @@
 package integration
 
 import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/cloudfoundry/bosh-gcscli/client"
 	"github.com/cloudfoundry/bosh-gcscli/config"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
 )
+
+// randReadSeeker is a ReadSeeker which returns random content and
+// non-nil error for every operation.
+//
+// crypto/rand is used to ensure any compression
+// applied to the reader's output doesn't effect the work we intend to do.
+type randReadSeeker struct {
+	reader io.Reader
+}
+
+func newrandReadSeeker(maxSize int64) randReadSeeker {
+	limited := io.LimitReader(rand.Reader, maxSize)
+	return randReadSeeker{limited}
+}
+
+func (rrs *randReadSeeker) Read(p []byte) (n int, err error) {
+	return rrs.reader.Read(p)
+}
+
+func (rrs *randReadSeeker) Seek(offset int64, whenc int) (n int64, err error) {
+	return offset, nil
+}
+
+// badReadSeeker is a ReadSeeker which returns a non-nil error
+// for every operation.
+type badReadSeeker struct{}
+
+var badReadSeekerErr = io.ErrUnexpectedEOF
+
+func (brs *badReadSeeker) Read(p []byte) (n int, err error) {
+	return 0, badReadSeekerErr
+}
+
+func (brs *badReadSeeker) Seek(offset int64, whenc int) (n int64, err error) {
+	return 0, badReadSeekerErr
+}
 
 var _ = Describe("Integration", func() {
 	Context("general (Default Applicaton Credentials) configuration", func() {
@@ -41,31 +85,66 @@ var _ = Describe("Integration", func() {
 			},
 			configurations...)
 
-		DescribeTable("Invalid Delete works",
+		DescribeTable("Delete silently ignores that the file doesn't exist",
 			func(config *config.GCSCli) {
 				ctx.AddConfig(config)
-				AssertDeleteNonexistentWorks(gcsCLIPath, ctx)
+
+				session, err := RunGCSCLI(gcsCLIPath, ctx.ConfigPath,
+					"delete", ctx.GCSFileName)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(session.ExitCode()).To(BeZero())
 			},
 			configurations...)
 
+		// Perform a large file put causing GCS to do a multi-part upload
 		DescribeTable("Multipart Put works",
 			func(config *config.GCSCli) {
 				ctx.AddConfig(config)
-				AssertMultipartPutWorks(gcsCLIPath, ctx)
+				if os.Getenv(NoLongEnv) != "" {
+					Skip(fmt.Sprintf(NoLongMsg, NoLongEnv))
+				}
+
+				const twoGB = 1024 * 1024 * 1024 * 2
+				limited := newrandReadSeeker(twoGB)
+
+				_, gcsClient, err := client.NewSDK(*ctx.Config)
+				Expect(err).ToNot(HaveOccurred())
+				blobstoreClient, err := client.New(context.Background(),
+					gcsClient, ctx.Config)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = blobstoreClient.Put(&limited, ctx.GCSFileName)
+				Expect(err).ToNot(HaveOccurred())
+
+				blobstoreClient.Delete(ctx.GCSFileName)
+				Expect(err).ToNot(HaveOccurred())
 			},
 			configurations...)
 
 		DescribeTable("Invalid Put should fail",
 			func(config *config.GCSCli) {
 				ctx.AddConfig(config)
-				AssertBrokenSourcePutFails(gcsCLIPath, ctx)
+
+				_, gcsClient, err := client.NewSDK(*ctx.Config)
+				Expect(err).ToNot(HaveOccurred())
+				blobstoreClient, err := client.New(context.Background(),
+					gcsClient, ctx.Config)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = blobstoreClient.Put(&badReadSeeker{}, ctx.GCSFileName)
+				Expect(err).To(HaveOccurred())
 			},
 			configurations...)
 
 		DescribeTable("Invalid Get should fail",
 			func(config *config.GCSCli) {
 				ctx.AddConfig(config)
-				AssertGetNonexistentFails(gcsCLIPath, ctx)
+
+				session, err := RunGCSCLI(gcsCLIPath, ctx.ConfigPath,
+					"get", ctx.GCSFileName, "/dev/null")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(session.ExitCode()).ToNot(BeZero())
+				Expect(session.Err.Contents()).To(ContainSubstring("object doesn't exist"))
 			},
 			configurations...)
 	})

--- a/integration/gcs_general_test.go
+++ b/integration/gcs_general_test.go
@@ -106,9 +106,7 @@ var _ = Describe("Integration", func() {
 				const twoGB = 1024 * 1024 * 1024 * 2
 				limited := newrandReadSeeker(twoGB)
 
-				gcsClient, err := client.NewSDK(env.ctx, *env.Config)
-				Expect(err).ToNot(HaveOccurred())
-				blobstoreClient, err := client.New(env.ctx, gcsClient, env.Config)
+				blobstoreClient, err := client.New(env.ctx, env.Config)
 				Expect(err).ToNot(HaveOccurred())
 
 				err = blobstoreClient.Put(&limited, env.GCSFileName)
@@ -123,9 +121,7 @@ var _ = Describe("Integration", func() {
 			func(config *config.GCSCli) {
 				env.AddConfig(config)
 
-				gcsClient, err := client.NewSDK(env.ctx, *env.Config)
-				Expect(err).ToNot(HaveOccurred())
-				blobstoreClient, err := client.New(env.ctx, gcsClient, env.Config)
+				blobstoreClient, err := client.New(env.ctx, env.Config)
 				Expect(err).ToNot(HaveOccurred())
 
 				err = blobstoreClient.Put(&badReadSeeker{}, env.GCSFileName)

--- a/integration/gcs_general_test.go
+++ b/integration/gcs_general_test.go
@@ -33,12 +33,9 @@ var _ = Describe("Integration", func() {
 			ctx.Cleanup()
 		})
 
-		baseConfigs, baseConfigErr := getBaseConfigs()
-		encryptedConfigs, encryptedConfigErr := getEncryptedConfigs()
-		configurations := append(baseConfigs, encryptedConfigs...)
+		configurations, baseConfigErr := getBaseConfigs()
 		It("fetches configurations", func() {
 			Expect(baseConfigErr).To(BeNil(), "failed to get configurations")
-			Expect(encryptedConfigErr).To(BeNil(), "failed to get configurations")
 		})
 
 		DescribeTable("Blobstore lifecycle works",

--- a/integration/gcs_general_test.go
+++ b/integration/gcs_general_test.go
@@ -95,10 +95,17 @@ var _ = Describe("Integration", func() {
 			},
 			configurations...)
 
-		// Perform a large file put causing GCS to do a multi-part upload
-		DescribeTable("Multipart Put works",
-			func(config *config.GCSCli) {
-				env.AddConfig(config)
+		Context("with a regional bucket", func() {
+			var cfg *config.GCSCli
+			BeforeEach(func() {
+				cfg = getRegionalConfig()
+				env.AddConfig(cfg)
+			})
+			AfterEach(func() {
+				env.Cleanup()
+			})
+
+			It("can perform large file upload (multi-part)", func() {
 				if os.Getenv(NoLongEnv) != "" {
 					Skip(fmt.Sprintf(NoLongMsg, NoLongEnv))
 				}
@@ -114,8 +121,8 @@ var _ = Describe("Integration", func() {
 
 				blobstoreClient.Delete(env.GCSFileName)
 				Expect(err).ToNot(HaveOccurred())
-			},
-			configurations...)
+			})
+		})
 
 		DescribeTable("Invalid Put should fail",
 			func(config *config.GCSCli) {

--- a/integration/gcs_general_test.go
+++ b/integration/gcs_general_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cloudfoundry/bosh-gcscli/config"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Integration", func() {
@@ -33,10 +32,7 @@ var _ = Describe("Integration", func() {
 			ctx.Cleanup()
 		})
 
-		configurations, baseConfigErr := getBaseConfigs()
-		It("fetches configurations", func() {
-			Expect(baseConfigErr).To(BeNil(), "failed to get configurations")
-		})
+		configurations := getBaseConfigs()
 
 		DescribeTable("Blobstore lifecycle works",
 			func(config *config.GCSCli) {

--- a/integration/gcs_public_test.go
+++ b/integration/gcs_public_test.go
@@ -38,9 +38,7 @@ var _ = Describe("GCS Public Bucket", func() {
 		)
 
 		BeforeEach(func() {
-			var err error
-			cfg, err = getPublicConfig()
-			Expect(err).NotTo(HaveOccurred())
+			cfg = getPublicConfig()
 
 			ctx = NewAssertContext(AsDefaultCredentials)
 			ctx.AddConfig(cfg)

--- a/integration/gcs_public_test.go
+++ b/integration/gcs_public_test.go
@@ -57,7 +57,7 @@ var _ = Describe("GCS Public Bucket", func() {
 				RunGCSCLI(gcsCLIPath, setupEnv.ConfigPath, "put", setupEnv.ContentFile, setupEnv.GCSFileName)
 
 				// Make the file public
-				rwClient, err := client.NewSDK(setupEnv.ctx, *setupEnv.Config)
+				rwClient, err := newSDK(setupEnv.ctx, *setupEnv.Config)
 				Expect(err).ToNot(HaveOccurred())
 				bucket := rwClient.Bucket(setupEnv.Config.BucketName)
 				obj := bucket.Object(setupEnv.GCSFileName)

--- a/integration/gcs_static_test.go
+++ b/integration/gcs_static_test.go
@@ -19,58 +19,25 @@ package integration
 import (
 	"github.com/cloudfoundry/bosh-gcscli/config"
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/extensions/table"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Integration", func() {
-	Context("static credentials configuration", func() {
-		var ctx AssertContext
+	Context("static credentials configuration with a regional bucket", func() {
+		var (
+			ctx AssertContext
+			cfg *config.GCSCli
+		)
 		BeforeEach(func() {
+			cfg = getRegionalConfig()
 			ctx = NewAssertContext(AsStaticCredentials)
+			ctx.AddConfig(cfg)
 		})
 		AfterEach(func() {
 			ctx.Cleanup()
 		})
 
-		configurations, baseConfigErr := getBaseConfigs()
-		It("fetches configurations", func() {
-			Expect(baseConfigErr).To(BeNil(), "failed to get configurations")
+		It("can perform blobstore lifecycle", func() {
+			AssertLifecycleWorks(gcsCLIPath, ctx)
 		})
-
-		DescribeTable("Blobstore lifecycle works",
-			func(config *config.GCSCli) {
-				ctx.AddConfig(config)
-				AssertLifecycleWorks(gcsCLIPath, ctx)
-			},
-			configurations...)
-
-		DescribeTable("Invalid Delete works",
-			func(config *config.GCSCli) {
-				ctx.AddConfig(config)
-				AssertDeleteNonexistentWorks(gcsCLIPath, ctx)
-			},
-			configurations...)
-
-		DescribeTable("Multipart Put works",
-			func(config *config.GCSCli) {
-				ctx.AddConfig(config)
-				AssertMultipartPutWorks(gcsCLIPath, ctx)
-			},
-			configurations...)
-
-		DescribeTable("Invalid Put should fail",
-			func(config *config.GCSCli) {
-				ctx.AddConfig(config)
-				AssertBrokenSourcePutFails(gcsCLIPath, ctx)
-			},
-			configurations...)
-
-		DescribeTable("Invalid Get should fail",
-			func(config *config.GCSCli) {
-				ctx.AddConfig(config)
-				AssertGetNonexistentFails(gcsCLIPath, ctx)
-			},
-			configurations...)
 	})
 })

--- a/integration/gcs_static_test.go
+++ b/integration/gcs_static_test.go
@@ -33,12 +33,9 @@ var _ = Describe("Integration", func() {
 			ctx.Cleanup()
 		})
 
-		baseConfigs, baseConfigErr := getBaseConfigs()
-		encryptedConfigs, encryptedConfigErr := getEncryptedConfigs()
-		configurations := append(baseConfigs, encryptedConfigs...)
+		configurations, baseConfigErr := getBaseConfigs()
 		It("fetches configurations", func() {
 			Expect(baseConfigErr).To(BeNil(), "failed to get configurations")
-			Expect(encryptedConfigErr).To(BeNil(), "failed to get configurations")
 		})
 
 		DescribeTable("Blobstore lifecycle works",

--- a/integration/gcs_storagecompat_test.go
+++ b/integration/gcs_storagecompat_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cloudfoundry/bosh-gcscli/config"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Integration", func() {
@@ -33,10 +32,7 @@ var _ = Describe("Integration", func() {
 			ctx.Cleanup()
 		})
 
-		configurations, configErr := getInvalidStorageClassConfigs()
-		It("fetches configurations", func() {
-			Expect(configErr).To(BeNil(), "failed to get configurations")
-		})
+		configurations := getInvalidStorageClassConfigs()
 
 		DescribeTable("Invalid Put should fail",
 			func(config *config.GCSCli) {

--- a/integration/gcs_storagecompat_test.go
+++ b/integration/gcs_storagecompat_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Integration", func() {
 			ctx.Cleanup()
 		})
 
-		configurations, configErr := getStorageCompatConfigs()
+		configurations, configErr := getInvalidStorageClassConfigs()
 		It("fetches configurations", func() {
 			Expect(configErr).To(BeNil(), "failed to get configurations")
 		})

--- a/integration/gcs_storagecompat_test.go
+++ b/integration/gcs_storagecompat_test.go
@@ -23,7 +23,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Integration", func() {
+var _ = Describe("StorageCompat Integration", func() {
 	Context("invalid storage_class for bucket (Default Applicaton Credentials) configuration", func() {
 		var ctx AssertContext
 		BeforeEach(func() {
@@ -39,8 +39,7 @@ var _ = Describe("Integration", func() {
 			func(config *config.GCSCli) {
 				ctx.AddConfig(config)
 
-				session, err := RunGCSCLI(gcsCLIPath, ctx.ConfigPath,
-					"put", ctx.ContentFile, ctx.GCSFileName)
+				session, err := RunGCSCLI(gcsCLIPath, ctx.ConfigPath, "put", ctx.ContentFile, ctx.GCSFileName)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(session.ExitCode()).ToNot(BeZero())
 			},

--- a/integration/gcs_storagecompat_test.go
+++ b/integration/gcs_storagecompat_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cloudfoundry/bosh-gcscli/config"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Integration", func() {
@@ -37,7 +38,11 @@ var _ = Describe("Integration", func() {
 		DescribeTable("Invalid Put should fail",
 			func(config *config.GCSCli) {
 				ctx.AddConfig(config)
-				AssertPutFails(gcsCLIPath, ctx)
+
+				session, err := RunGCSCLI(gcsCLIPath, ctx.ConfigPath,
+					"put", ctx.ContentFile, ctx.GCSFileName)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(session.ExitCode()).ToNot(BeZero())
 			},
 			configurations...)
 	})

--- a/main.go
+++ b/main.go
@@ -27,29 +27,23 @@ import (
 	"golang.org/x/net/context"
 )
 
-var version string
+var version = "dev"
 
 // usageExample provides examples of how to use the CLI.
-//
-// This is used when printing the help text.
 const usageExample = `
 # Usage
 bosh-gcscli --help
 
-# Command: "put"
 # Upload a blob to the GCS blobstore.
 bosh-gcscli -c config.json put <path/to/file> <remote-blob>
 
-# Command: "get"
 # Fetch a blob from the GCS blobstore.
 # Destination file will be overwritten if exists.
 bosh-gcscli -c config.json get <remote-blob> <path/to/file>
 
-# Command: "delete"
 # Remove a blob from the GCS blobstore.
 bosh-gcscli -c config.json delete <remote-blob>
 
-# Command: "exists"
 # Checks if blob exists in the GCS blobstore.
 bosh-gcscli -c config.json exists <remote-blob>`
 
@@ -58,30 +52,27 @@ var (
 	shortHelp  = flag.Bool("h", false, "Print this help text")
 	longHelp   = flag.Bool("help", false, "Print this help text")
 	configPath = flag.String("c", "",
-		`JSON config file (ie, config.json).
+		`path to a JSON file with the following contents:
 	{
-		"bucket_name":         "name of GCS bucket (required)",
-
-		"credentials_source":  "flag for credentials
-		                        (optional, defaults to Application Default Credentials)
-		                        (can be "static" for json_key),
-		                        (can be "none" for explicitly no credentials)"
+		"bucket_name":         "name of Google Cloud Storage bucket (required)",
+		"credentials_source":  "Optional, defaults to Application Default Credentials or none)
+		                        (can be 'static' for a service account specified in json_key),
+		                        (can be 'none' for explicitly no credentials)"
+		"json_key":            "JSON Service Account File
+		                        (optional, required for 'static' credentials)",
 		"storage_class":       "storage class for objects
 		                        (optional, defaults to bucket settings)",
-		"json_key":            "JSON Service Account File
-		                        (optional, required for static credentials)",
 		"encryption_key":      "Base64 encoded 32 byte Customer-Supplied
-		                        encryption key used to encrypt objects 
-		                        (optional)"
+		                        encryption key used to encrypt objects
+								(optional, defaults to GCS controlled key)"
 	}
 
 	storage_class is one of MULTI_REGIONAL, REGIONAL, NEARLINE, or COLDLINE.
-	See the docs for characteristics and location compatibility.
-	https://cloud.google.com/storage/docs/storage-classes
+	For more information on characteristics and location compatibility:
+	    https://cloud.google.com/storage/docs/storage-classes
 
-	For more information on Customer-Supplied encryption keys,
-	see the docs.
-	https://cloud.google.com/storage/docs/encryption
+	For more information on Customer-Supplied encryption keys:
+		https://cloud.google.com/storage/docs/encryption
 `)
 )
 
@@ -93,7 +84,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	if *shortHelp || *longHelp {
+	if *shortHelp || *longHelp || len(flag.Args()) == 0 {
 		flag.Usage()
 		fmt.Println(usageExample)
 		os.Exit(0)
@@ -129,7 +120,7 @@ func main() {
 	switch cmd {
 	case "put":
 		if len(nonFlagArgs) != 3 {
-			log.Fatalf("Put method expected 3 arguments got %d\n", len(nonFlagArgs))
+			log.Fatalf("put method expected 3 arguments got %d\n", len(nonFlagArgs))
 		}
 		src, dst := nonFlagArgs[1], nonFlagArgs[2]
 
@@ -144,7 +135,7 @@ func main() {
 		fmt.Println(err)
 	case "get":
 		if len(nonFlagArgs) != 3 {
-			log.Fatalf("Get method expected 3 arguments got %d\n", len(nonFlagArgs))
+			log.Fatalf("get method expected 3 arguments got %d\n", len(nonFlagArgs))
 		}
 		src, dst := nonFlagArgs[1], nonFlagArgs[2]
 
@@ -158,13 +149,13 @@ func main() {
 		err = blobstoreClient.Get(src, dstFile)
 	case "delete":
 		if len(nonFlagArgs) != 2 {
-			log.Fatalf("Delete method expected 2 arguments got %d\n", len(nonFlagArgs))
+			log.Fatalf("delete method expected 2 arguments got %d\n", len(nonFlagArgs))
 		}
 
 		err = blobstoreClient.Delete(nonFlagArgs[1])
 	case "exists":
 		if len(nonFlagArgs) != 2 {
-			log.Fatalf("Exists method expected 2 arguments got %d\n", len(nonFlagArgs))
+			log.Fatalf("exists method expected 2 arguments got %d\n", len(nonFlagArgs))
 		}
 
 		var exists bool

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cloudfoundry/bosh-gcscli/client"
 	"github.com/cloudfoundry/bosh-gcscli/config"
+	"golang.org/x/net/context"
 )
 
 var version string
@@ -112,7 +113,8 @@ func main() {
 		log.Fatalf("reading config %s: %v\n", *configPath, err)
 	}
 
-	ctx, gcsClient, err := client.NewSDK(gcsConfig)
+	ctx := context.Background()
+	gcsClient, err := client.NewSDK(ctx, gcsConfig)
 	if err != nil {
 		log.Fatalf("creating gcs sdk: %v\n", err)
 	}

--- a/main.go
+++ b/main.go
@@ -114,12 +114,7 @@ func main() {
 	}
 
 	ctx := context.Background()
-	gcsClient, err := client.NewSDK(ctx, gcsConfig)
-	if err != nil {
-		log.Fatalf("creating gcs sdk: %v\n", err)
-	}
-
-	blobstoreClient, err := client.New(ctx, gcsClient, &gcsConfig)
+	blobstoreClient, err := client.New(ctx, &gcsConfig)
 	if err != nil {
 		log.Fatalf("creating gcs client: %v\n", err)
 	}


### PR DESCRIPTION
user facing changes:

- client API has changed. There is now a single `New` method that expects a `config.GCSClient`. For more details see 464c3ab
- `storage_class` settings are now only validated on `put`. This was causing failures when an actor had access to specific objects but not to the bucket settings (eg public objects)
- Client falls back to `none` credentials mode when the application default credentials fail. This is to address behavior on GCE when the instance has a service account associated but does not have scope to the storage API. This prevented access to public buckets when attempting to fetch a token for authenticating.
- Client re-attempts "put" operation up to 3 times if it fails to upload
- Updated documentation/contributing guide

developer facing:
- reduced integration testing matrix, some test refactoring