### PR TITLE
Promote Develop

### DIFF
--- a/client/sdk.go
+++ b/client/sdk.go
@@ -20,75 +20,35 @@ import (
 	"context"
 	"errors"
 
-	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 
 	"google.golang.org/api/option"
 
 	"net/http"
 
-	"cloud.google.com/go/compute/metadata"
 	"cloud.google.com/go/storage"
 	"github.com/cloudfoundry/bosh-gcscli/config"
 )
 
 const uaString = "bosh-gcscli"
 
-func newStorageClient(ctx context.Context, cfg *config.GCSCli) (*storage.Client, bool, error) {
-	// default to a read-only client
-	readOnly := true
-	opt := option.WithHTTPClient(http.DefaultClient)
+func newStorageClients(ctx context.Context, cfg *config.GCSCli) (*storage.Client, *storage.Client, error) {
+	publicClient, err := storage.NewClient(ctx, option.WithUserAgent(uaString), option.WithHTTPClient(http.DefaultClient))
+	var authenticatedClient *storage.Client
 
 	switch cfg.CredentialsSource {
 	case config.NoneCredentialsSource:
 		// no-op
 	case config.DefaultCredentialsSource:
-		// attempt to load the application default credentials
-		if tokenSource, err := getDefaultTokenSource(ctx); err == nil {
-			opt = option.WithTokenSource(tokenSource)
-			readOnly = false
+		if tokenSource, err := google.DefaultTokenSource(ctx, storage.ScopeFullControl); err == nil {
+			authenticatedClient, err = storage.NewClient(ctx, option.WithUserAgent(uaString), option.WithTokenSource(tokenSource))
 		}
 	case config.ServiceAccountFileCredentialsSource:
 		if token, err := google.JWTConfigFromJSON([]byte(cfg.ServiceAccountFile), storage.ScopeFullControl); err == nil {
-			opt = option.WithTokenSource(token.TokenSource(ctx))
-			readOnly = false
+			authenticatedClient, err = storage.NewClient(ctx, option.WithUserAgent(uaString), option.WithTokenSource(token.TokenSource(ctx)))
 		}
 	default:
-		return nil, false, errors.New("unknown credentials_source in configuration")
+		return nil, nil, errors.New("unknown credentials_source in configuration")
 	}
-
-	gcs, err := storage.NewClient(ctx, option.WithUserAgent(uaString), opt)
-
-	return gcs, readOnly, err
-}
-
-// If we're on GCE then google.DefaultTokenSource may return the default service account.
-// If that account doesn't have storage.ScopeFullControl then we do not want it.
-func useDefaultTokenSource() bool {
-	if !metadata.OnGCE() {
-		return true
-	}
-
-	scopes, err := metadata.Scopes("")
-	if err != nil {
-		// no default service account to use
-		return false
-	}
-
-	for _, scope := range scopes {
-		if scope == storage.ScopeFullControl {
-			// default service account has proper scope, it's fine to use it
-			return true
-		}
-	}
-
-	return false
-}
-
-func getDefaultTokenSource(ctx context.Context) (oauth2.TokenSource, error) {
-	if !useDefaultTokenSource() {
-		return nil, errors.New("refusing to use default token source")
-	}
-
-	return google.DefaultTokenSource(ctx, storage.ScopeFullControl)
+	return authenticatedClient, publicClient, err
 }


### PR DESCRIPTION
- client will now fall back to using a public GCS client if the authenticated client fails for `get` or `exists`. This is needed on GCE where the authenticated client may be an empty default service account. In that scenario we need to use the public GCS client to fetch public blobs. See #17 for more info.