### PR TITLE
Update golang in docker image to 1.10.2

### DIFF
--- a/ci/docker-image/Dockerfile
+++ b/ci/docker-image/Dockerfile
@@ -13,12 +13,12 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y -qq update && apt-get -y -qq insta
 WORKDIR /tmp/docker-build
 
 # Golang
-ENV GO_VERSION=1.8.3
-ENV GO_SHA1SUM=838c415896ef5ecd395dfabde5e7e6f8ac943c8e
+ENV GO_VERSION=1.10.2
+ENV GO_SHA2SUM=4b677d698c65370afa33757b6954ade60347aaca310ea92a63ed717d7cb0c2ff
 
 RUN curl -LO https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz && \
-    echo "${GO_SHA1SUM}  go${GO_VERSION}.linux-amd64.tar.gz" > go_${GO_VERSION}_SHA1SUM && \
-    sha1sum -cw --status go_${GO_VERSION}_SHA1SUM
+    echo "${GO_SHA2SUM}  go${GO_VERSION}.linux-amd64.tar.gz" > go_${GO_VERSION}_SHA1SUM && \
+    shasum -a 256 -cw --status go_${GO_VERSION}_SHA1SUM
 RUN tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz
 ENV GOPATH /root/go
 RUN mkdir -p /root/go/bin


### PR DESCRIPTION
Hi! We had a story around upgrading dependencies to the latest go version. Let us know if there's anything else we can do for this. Thanks!

@luan && @dpb587-pivotal