### PR TITLE
attempt to fix #20

### DIFF
--- a/client/client_suite_test.go
+++ b/client/client_suite_test.go
@@ -1,0 +1,25 @@
+// This file was adapted from: https://github.com/cloudfoundry/bosh-google-cpi-release
+//
+// Copyright (c) 2015-Present CloudFoundry.org Foundation, Inc. All Rights Reserved.
+//
+// This project is licensed to you under the Apache License, Version 2.0 (the "License").
+//
+// You may not use this project except in compliance with the License.
+//
+// This project may include a number of subcomponents with separate copyright notices
+// and license terms. Your use of these subcomponents is subject to the terms and
+// conditions of the subcomponent's license, as noted in the LICENSE file.
+
+package client_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestGoogleClient(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Client Suite")
+}

--- a/client/retry.go
+++ b/client/retry.go
@@ -1,0 +1,95 @@
+// This file was adapted from: https://github.com/cloudfoundry/bosh-google-cpi-release
+//
+// Copyright (c) 2015-Present CloudFoundry.org Foundation, Inc. All Rights Reserved.
+//
+// This project is licensed to you under the Apache License, Version 2.0 (the "License").
+//
+// You may not use this project except in compliance with the License.
+//
+// This project may include a number of subcomponents with separate copyright notices
+// and license terms. Your use of these subcomponents is subject to the terms and
+// conditions of the subcomponent's license, as noted in the LICENSE file.
+
+package client
+
+import (
+	"bytes"
+	"io/ioutil"
+	"log"
+	"net"
+	"net/http"
+	"time"
+)
+
+const (
+	defaultFirstRetrySleep = 50 * time.Millisecond
+)
+
+// RequestModifier is a function that will modify the request before it is made
+type RequestModifier func(req *http.Request)
+
+// RetryTransport is a function that will retry failed HTTP connections up to
+// a maximum number of times.
+type RetryTransport struct {
+	MaxRetries      int
+	FirstRetrySleep time.Duration
+	Base            http.RoundTripper
+	RequestModifier RequestModifier
+}
+
+func (rt *RetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return rt.try(req)
+}
+
+func (rt *RetryTransport) try(req *http.Request) (resp *http.Response, err error) {
+	if rt.FirstRetrySleep == 0 {
+		rt.FirstRetrySleep = defaultFirstRetrySleep
+	}
+
+	var body []byte
+
+	if rt.RequestModifier != nil {
+		rt.RequestModifier(req)
+	}
+
+	// Save the req body for future retries as it will be read and closed
+	// by Base.RoundTrip.
+	if req.Body != nil {
+		body, err = ioutil.ReadAll(req.Body)
+		if err != nil {
+			return
+		}
+	}
+
+	for try := 0; try <= rt.MaxRetries; try++ {
+		r := bytes.NewReader(body)
+		req.Body = ioutil.NopCloser(r)
+		resp, err = rt.Base.RoundTrip(req)
+
+		sleep := func() {
+			d := rt.FirstRetrySleep << uint64(try)
+			log.Printf("RetryTransport: Retrying request (%d/%d) after %s", try, rt.MaxRetries, d)
+			time.Sleep(d)
+		}
+
+		// Retry on net.Error
+		switch err.(type) {
+		case net.Error:
+			if !err.(net.Error).Temporary() {
+				return
+			}
+			sleep()
+			continue
+		case error:
+			return
+		}
+
+		// Retry on status code >= 500
+		if resp.StatusCode >= 500 {
+			sleep()
+			continue
+		}
+		return
+	}
+	return
+}

--- a/client/retry_test.go
+++ b/client/retry_test.go
@@ -1,0 +1,166 @@
+// This file was adapted from: https://github.com/cloudfoundry/bosh-google-cpi-release
+//
+// Copyright (c) 2015-Present CloudFoundry.org Foundation, Inc. All Rights Reserved.
+//
+// This project is licensed to you under the Apache License, Version 2.0 (the "License").
+//
+// You may not use this project except in compliance with the License.
+//
+// This project may include a number of subcomponents with separate copyright notices
+// and license terms. Your use of these subcomponents is subject to the terms and
+// conditions of the subcomponent's license, as noted in the LICENSE file.
+
+package client
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"time"
+)
+
+type errorTransport struct {
+	try int
+}
+
+func (e *errorTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	e.try++
+	return nil, &net.DNSError{IsTimeout: false, IsTemporary: true}
+}
+
+var _ = Describe("RetryTransport", func() {
+
+	Describe("Validate", func() {
+		It("It uses a default sleep duration if one isn't provided", func() {
+			maxRetries := 1
+			et := &errorTransport{}
+			client := http.Client{
+				Transport: &RetryTransport{
+					Base:            et,
+					MaxRetries:      maxRetries,
+					FirstRetrySleep: 50 * time.Millisecond,
+				},
+			}
+			_, err := client.Get("http://0.0.0.0")
+			Expect(et.try).To(Equal(maxRetries + 1))
+			Expect(err).To(HaveOccurred())
+			Expect(client.Transport.(*RetryTransport).FirstRetrySleep != 0)
+		})
+
+		It("It retries the maximum number of times and then fails", func() {
+			maxRetries := 3
+			et := &errorTransport{}
+			client := http.Client{
+				Transport: &RetryTransport{
+					Base:       et,
+					MaxRetries: maxRetries,
+				},
+			}
+
+			_, err := client.Get("http://0.0.0.0")
+			Expect(et.try).To(Equal(maxRetries + 1))
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("It retries the maximum number of times and then fails", func() {
+			maxRetries := 3
+			try := 0
+
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				try++
+				w.WriteHeader(http.StatusServiceUnavailable)
+			}))
+			defer ts.Close()
+
+			client := http.Client{
+				Transport: &RetryTransport{
+					Base:       http.DefaultTransport,
+					MaxRetries: maxRetries,
+				},
+			}
+
+			res, err := client.Get(ts.URL)
+			Expect(try).To(Equal(maxRetries + 1))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res.StatusCode).To(Equal(http.StatusServiceUnavailable))
+		})
+
+		It("It retries the maximum number and succeeds on the last try", func() {
+			maxRetries := 3
+			try := 0
+
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if try == maxRetries {
+					w.WriteHeader(http.StatusOK)
+				} else {
+					w.WriteHeader(http.StatusServiceUnavailable)
+				}
+				try++
+			}))
+			defer ts.Close()
+
+			client := http.Client{
+				Transport: &RetryTransport{
+					Base:       http.DefaultTransport,
+					MaxRetries: maxRetries,
+				},
+			}
+
+			res, err := client.Get(ts.URL)
+			Expect(try).To(Equal(maxRetries + 1))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res.StatusCode).To(Equal(http.StatusOK))
+		})
+
+		It("It retries zero times and succeeds", func() {
+			maxRetries := 0
+			try := 0
+
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				try++
+			}))
+			defer ts.Close()
+
+			client := http.Client{
+				Transport: &RetryTransport{
+					Base:       http.DefaultTransport,
+					MaxRetries: maxRetries,
+				},
+			}
+			res, err := client.Get(ts.URL)
+			Expect(try).To(Equal(maxRetries + 1))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res.StatusCode).To(Equal(http.StatusServiceUnavailable))
+		})
+
+		It("It retries zero times and succeeds", func() {
+			maxRetries := 0
+			try := 0
+
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if try == maxRetries {
+					w.WriteHeader(http.StatusOK)
+				} else {
+					w.WriteHeader(http.StatusServiceUnavailable)
+				}
+				try++
+			}))
+			defer ts.Close()
+
+			client := http.Client{
+				Transport: &RetryTransport{
+					Base:       http.DefaultTransport,
+					MaxRetries: maxRetries,
+				},
+			}
+			res, err := client.Get(ts.URL)
+			Expect(try).To(Equal(maxRetries + 1))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res.StatusCode).To(Equal(http.StatusOK))
+		})
+	})
+})


### PR DESCRIPTION
This is a proposed fix for #20. I brought in the retry code from `bosh-google-cpi-release`.

The fix is hacky because the OAUTH initializer just grabs go's default HTTP transport, so we have to change it in the function to the retrier and swap it back once we're done.

The timeouts aren't set in stone, and there might be better options. This is also a difficult thing to test so ideas would be appreciated.