### PR TITLE
Remove git rev and timestamp from version number

### DIFF
--- a/ci/tasks/build.sh
+++ b/ci/tasks/build.sh
@@ -14,7 +14,6 @@ semver_dir="${workspace_dir}/version-semver"
 output_dir=${workspace_dir}/out
 
 semver="$(cat "${semver_dir}/number")"
-timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 export CGO_ENABLED=0
 
 binname="bosh-gcscli-${semver}-${GOOS}-amd64"
@@ -23,11 +22,8 @@ if [ "${GOOS}" = "windows" ]; then
 fi
 
 pushd "${release_dir}" > /dev/null
-  git_rev=$(git rev-parse --short HEAD)
-  version="${semver}-${git_rev}-${timestamp}"
-
   echo -e "\n building artifact using $(go version)..."
-  go build -ldflags "-X main.version=${version}" \
+  go build -ldflags "-X main.version=${semver}" \
     -o "out/${binname}"                          \
     github.com/cloudfoundry/bosh-gcscli
 


### PR DESCRIPTION
This will allow us to "go get NAME@VERSION" and have go mod correctly download the source