### PR TITLE
Lint: use context from stdlib

### DIFF
--- a/integration/assertcontext.go
+++ b/integration/assertcontext.go
@@ -17,13 +17,13 @@
 package integration
 
 import (
+	"context"
 	"fmt"
 	"os"
 
 	"github.com/cloudfoundry/bosh-gcscli/config"
 
 	. "github.com/onsi/gomega" //nolint:staticcheck
-	"golang.org/x/net/context"
 )
 
 // GoogleAppCredentialsEnv is the environment variable
@@ -110,12 +110,11 @@ func (ctx *AssertContext) AddConfig(config *config.GCSCli) {
 // The behavior for an AssertContextAuthOption is applied when config is added
 type AssertContextConfigOption func(ctx *AssertContext)
 
-// AsReadOnlyCredentials configures the AssertContext to be used soley for
+// AsReadOnlyCredentials configures the AssertContext to be used solely for
 // public, read-only operations.
 func AsReadOnlyCredentials(ctx *AssertContext) {
 	conf := ctx.Config
-	Expect(conf).ToNot(BeNil(),
-		"cannot set read-only AssertContext without config")
+	Expect(conf).ToNot(BeNil(), "cannot set read-only AssertContext without config")
 
 	conf.CredentialsSource = config.NoneCredentialsSource
 	conf.ServiceAccountFile = ""
@@ -125,8 +124,7 @@ func AsReadOnlyCredentials(ctx *AssertContext) {
 // using a Service Account File
 func AsStaticCredentials(ctx *AssertContext) {
 	conf := ctx.Config
-	Expect(conf).ToNot(BeNil(),
-		"cannot set static AssertContext without config")
+	Expect(conf).ToNot(BeNil(), "cannot set static AssertContext without config")
 
 	conf.ServiceAccountFile = ctx.serviceAccountFile
 	conf.CredentialsSource = config.ServiceAccountFileCredentialsSource
@@ -137,8 +135,7 @@ func AsStaticCredentials(ctx *AssertContext) {
 // testing service account file.
 func AsDefaultCredentials(ctx *AssertContext) {
 	conf := ctx.Config
-	Expect(conf).ToNot(BeNil(),
-		"cannot set static AssertContext without config")
+	Expect(conf).ToNot(BeNil(), "cannot set static AssertContext without config")
 
 	tempFile, err := os.CreateTemp("", "bosh-gcscli-service-account-file")
 	Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Fixes https://bosh.ci.cloudfoundry.org/teams/storage-cli/pipelines/bosh-gcs-cli/jobs/bump-deps/builds/15#L69155dd6:1375:1382

```
github.com/golangci/golangci-lint/v2/cmd/golangci-lint
integration/assertcontext.go:26:2: SA1019: "golang.org/x/net/context" is deprecated: Use the standard library context package instead. (staticcheck)
	"golang.org/x/net/context"
	^
main.go:28:2: SA1019: "golang.org/x/net/context" is deprecated: Use the standard library context package instead. (staticcheck)
	"golang.org/x/net/context"
	^
2 issues:
* staticcheck: 2
```