### PR TITLE
Lint: use `context` from stdlib

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -24,8 +25,6 @@ import (
 	"os"
 	"strings"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"github.com/cloudfoundry/bosh-gcscli/client"
 	"github.com/cloudfoundry/bosh-gcscli/config"


### PR DESCRIPTION
Fixes
```
main.go:28:2: SA1019: "golang.org/x/net/context" is deprecated: Use the standard library context package instead. (staticcheck)
	"golang.org/x/net/context"
	^
1 issues:
* staticcheck: 1
```