### PR TITLE
ci: Remove develop/main branch pattern

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,13 +10,13 @@ including your gem version, Ruby version, and operating system. Ideally, a bug r
 ## Submitting a Pull Request
 You can add a feature or bug-fix via pull request.
 1. Fork the project
-1. Create a branch for your feature or fix from the `develop` branch. Replace `your-feature-name` with a description of your feature or fix:
+1. Create a branch for your feature or fix from the `main` branch. Replace `your-feature-name` with a description of your feature or fix:
    ```
-   git checkout -b your-feature-name develop
+   git checkout -b your-feature-name main
    ```
 1. Implement your feature or bug fix
 1. Commit and push your changes
-1. Submit a pull request to the `develop` branch of the [bosh-gcscli] repository. PRs to the main branch are not accepted.
+1. Submit a pull request to the `main` branch of the [bosh-gcscli] repository. PRs to the main branch are not accepted.
 1. Unit tests and a BOSH release are created for each PR. You should see the status of your PR change to "pending" within a few minutes of submitting it, and then to "passed" or "failed" within 10 minutes.
 
 [bosh-gcscli]: https://github.com/cloudfoundry/bosh-gcscli/

--- a/ci/README.md
+++ b/ci/README.md
@@ -21,16 +21,3 @@ fly -t google set-pipeline -p bosh-gcscli -c pipeline.yml -l credentials.yml
 ```
 fly -t google unpause-pipeline -p bosh-gcscli
 ```
-
-## Development pipeline
-
-`pipeline-develop.yml` contains the functional tests without the release
-handling. For development, it is recommended to use this as it is significantly
-easier to setup.
-
-To prepare, follow the above steps with the following exceptions.
-
-* Use `pipeline-develop.yml` instead of `pipeline.yml`
-
-* Change the `bosh-gcscli-src-in` to reference your development repository and
-branch.

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,9 +1,9 @@
 jobs:
-  - name: run-unit-develop
+  - name: run-unit
+    old_name: run-unit-main
     plan:
     - trigger: true
       get: gcscli-src
-      resource: bosh-gcscli-src-in-develop
     - get: bosh-gcscli-image
       trigger: true
 
@@ -11,25 +11,11 @@ jobs:
       image: bosh-gcscli-image
       file: gcscli-src/ci/tasks/run-unit.yml
 
-  - name: run-unit-main
+  - name: run-fast-int
+    old_name: run-fast-int-main
     plan:
     - trigger: true
       get: gcscli-src
-      resource: bosh-gcscli-src-in-main
-      passed:
-      - promote-develop
-    - get: bosh-gcscli-image
-      trigger: true
-
-    - task: unit-tests
-      image: bosh-gcscli-image
-      file: gcscli-src/ci/tasks/run-unit.yml
-
-  - name: run-fast-int-develop
-    plan:
-    - trigger: true
-      get: gcscli-src
-      resource: bosh-gcscli-src-in-develop
     - get: bosh-gcscli-image
       trigger: true
 
@@ -39,27 +25,11 @@ jobs:
       params:
         google_json_key_data: ((gcp_service_key_json))
 
-  - name: run-fast-int-main
+  - name: run-int
+    old_name: run-int-main
     plan:
     - trigger: true
       get: gcscli-src
-      resource: bosh-gcscli-src-in-main
-      passed:
-      - promote-develop
-    - get: bosh-gcscli-image
-      trigger: true
-
-    - task: fast-integration-tests
-      image: bosh-gcscli-image
-      file: gcscli-src/ci/tasks/run-fast-int.yml
-      params:
-        google_json_key_data: ((gcp_service_key_json))
-
-  - name: run-int-develop
-    plan:
-    - trigger: true
-      get: gcscli-src
-      resource: bosh-gcscli-src-in-develop
     - get: bosh-gcscli-image
       trigger: true
 
@@ -69,41 +39,25 @@ jobs:
       params:
         google_json_key_data: ((gcp_service_key_json))
 
-  - name: run-int-main
-    plan:
-    - trigger: true
-      get: gcscli-src
-      resource: bosh-gcscli-src-in-main
-      passed:
-      - promote-develop
-    - get: bosh-gcscli-image
-      trigger: true
-
-    - task: full-integration-tests
-      image: bosh-gcscli-image
-      file: gcscli-src/ci/tasks/run-int.yml
-      params:
-        google_json_key_data: ((gcp_service_key_json))
-
-  - name: promote-main
+  - name: promote
+    old_name: promote-main
     plan:
     - in_parallel:
       - get: gcscli-src
-        resource: bosh-gcscli-src-in-main
+
         trigger: true
         passed:
-        - run-unit-main
-        - run-fast-int-main
-        - run-int-main
+        - run-unit
+        - run-fast-int
+        - run-int
       - get: bosh-gcscli-image
         trigger: true
         passed:
-          - run-unit-main
-          - run-fast-int-main
-          - run-int-main
+          - run-unit
+          - run-fast-int
+          - run-int
 
       - put: version-semver
-        resource: version-semver-main
         params:
           bump: patch
     - in_parallel:
@@ -123,11 +77,9 @@ jobs:
           GOOS: windows
     - in_parallel:
       - put: release-bucket-linux
-        resource: release-bucket-linux-main
         params:
           file: out-linux/bosh-gcscli-*-linux-amd64
       - put: release-bucket-windows
-        resource: release-bucket-windows-main
         params:
           file: out-windows/bosh-gcscli-*-windows-amd64.exe
     - params:
@@ -135,26 +87,10 @@ jobs:
         tag: version-semver/number
         tag_prefix: v
       put: gcscli-src
-      resource: bosh-gcscli-src-in-main
-
-  - name: promote-develop
-    plan:
-    - get: gcscli-src
-      resource: bosh-gcscli-src-in-develop
-      trigger: true
-      passed:
-      - run-unit-develop
-      - run-fast-int-develop
-      - run-int-develop
-    - put: gcs-cli
-      resource: bosh-gcscli-src-in-main
-      params:
-        repository: gcscli-src
 
   - name: build-docker
     plan:
       - get: gcscli-src
-        resource: bosh-gcscli-src-in-develop
       - get: bosh-golang-release-image
         trigger: true
       - task: build-image
@@ -183,7 +119,6 @@ jobs:
     plan:
     - in_parallel:
       - get: gcscli-src
-        resource: bosh-gcscli-src-in-develop
       - get: golang-release
       - get: weekly
         trigger: true
@@ -200,7 +135,7 @@ jobs:
       image: bosh-gcscli-image
       input_mapping:
         gcscli-src: bumped-gcscli-src
-    - put: bosh-gcscli-src-in-develop
+    - put: gcscli-src
       params:
         repository: bumped-gcscli-src
         rebase: true
@@ -228,14 +163,7 @@ resources:
       username: ((github_read_write_packages.username))
       password: ((github_read_write_packages.password))
 
-  - name: bosh-gcscli-src-in-develop
-    type: git
-    source:
-      uri: git@github.com:cloudfoundry/bosh-gcscli.git
-      branch: develop
-      private_key: ((github_deploy_key_bosh-gcscli.private_key))
-
-  - name: bosh-gcscli-src-in-main
+  - name: gcscli-src
     type: git
     source:
       uri: git@github.com:cloudfoundry/bosh-gcscli.git
@@ -247,7 +175,7 @@ resources:
     source:
       uri: https://github.com/cloudfoundry/bosh-package-golang-release.git
 
-  - name: version-semver-main
+  - name: version-semver
     type: semver
     source:
       initial_version: 0.0.1
@@ -256,7 +184,7 @@ resources:
       access_key_id: ((bosh_gcscli_pipeline.username))
       secret_access_key: ((bosh_gcscli_pipeline.password))
 
-  - name: release-bucket-linux-main
+  - name: release-bucket-linux
     type: s3
     source:
       regexp: bosh-gcscli-(.*)-linux-amd64
@@ -264,7 +192,7 @@ resources:
       access_key_id: ((bosh_gcscli_pipeline.username))
       secret_access_key: ((bosh_gcscli_pipeline.password))
 
-  - name: release-bucket-windows-main
+  - name: release-bucket-windows
     type: s3
     source:
       regexp: bosh-gcscli-(.*)-windows-amd64\.exe


### PR DESCRIPTION
The CI jobs for both develop and main were identical, running the same tests against their respective branches. The promote-develop jobs, which pushes develop into main, regularly fails because PRs are merged into main instead of develop.

Since the testing is the same, the develop / main pattern provides no value. This commit updates the pipeline to just run tests against main.

---

This change has NOT been flown, so we will need to run `ci/configure.sh` after it's merged. Additionally, the develop branch itself should be deleted after merging this.